### PR TITLE
Keep Annotator's showTags property using the State Hook

### DIFF
--- a/src/components/ImageSegmentation/index.js
+++ b/src/components/ImageSegmentation/index.js
@@ -33,6 +33,7 @@ export default ({
 }) => {
   const c = useStyles()
   const [selectedIndex, changeSelectedIndex] = useState(0)
+  const [showTags, changeShowTags] = useState(true)
 
   const { regionTypesAllowed = ["bounding-box"] } = iface
 
@@ -69,6 +70,7 @@ export default ({
         onSaveTaskOutputItem(i, regionMat[i][0])
       }
     }
+    changeShowTags(output.showTags)
     if (containerProps.onExit) containerProps.onExit(nextAction)
   })
   const onNextImage = useEventCallback((output) => {
@@ -110,6 +112,7 @@ export default ({
         key={globalSampleIndex}
         selectedImage={taskData[selectedIndex].imageUrl}
         taskDescription={iface.description}
+        showTags={showTags}
         {...labelProps}
         onNextImage={onNextImage}
         onPrevImage={onPrevImage}


### PR DESCRIPTION
Hi, I'm not used to React, Electron (I mean .... all the modern JS) and so on. So please go easy on me.

This PR adds a state to ImageSegmentation component.
The purpose is to keep the state of Annotator's showTags property.
When I moved to Next/Prev sample, it goes back to default value (true),
but I want it to be set as user specified value.
