### PR TITLE
Keep Annotator's selectedTool state in ImageSegmentation component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24056,9 +24056,9 @@
       }
     },
     "react-image-annotate": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/react-image-annotate/-/react-image-annotate-1.0.4.tgz",
-      "integrity": "sha512-CMI57nWhZJSiE25snvX0Y2z5jXGiYth0MMaMiHYo9Nv6eALaoQyUS+H+UD8isZNLYpbyAhzxjmW66W8TaxxiZw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/react-image-annotate/-/react-image-annotate-1.0.6.tgz",
+      "integrity": "sha512-IogOgz/oXOtP6qAFo/nFym/m/yHsvUHILUIL1UvuX4TYuBTxYKOByRA50axqInfyAfKbMsbfYYa7UcoaiAxzug==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.12",
         "@fortawesome/free-solid-svg-icons": "^5.6.3",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "react-data-table-component": "^6.2.2",
     "react-dropzone": "^10.1.8",
     "react-icons": "^3.9.0",
-    "react-image-annotate": "^1.0.4",
+    "react-image-annotate": "^1.0.6",
     "react-scripts": "^3.4.1",
     "react-select": "^3.0.8",
     "rfc6902": "^3.0.4",

--- a/src/components/ImageSegmentation/index.js
+++ b/src/components/ImageSegmentation/index.js
@@ -34,6 +34,7 @@ export default ({
   const c = useStyles()
   const [selectedIndex, changeSelectedIndex] = useState(0)
   const [showTags, changeShowTags] = useState(true)
+  const [selectedTool, changeSelectedTool] = useState("select")
 
   const { regionTypesAllowed = ["bounding-box"] } = iface
 
@@ -71,6 +72,7 @@ export default ({
       }
     }
     changeShowTags(output.showTags)
+    changeSelectedTool(output.selectedTool)
     if (containerProps.onExit) containerProps.onExit(nextAction)
   })
   const onNextImage = useEventCallback((output) => {
@@ -117,6 +119,7 @@ export default ({
         onNextImage={onNextImage}
         onPrevImage={onPrevImage}
         enabledTools={enabledTools}
+        selectedTool={selectedTool}
         images={images}
         onExit={onExit}
       />


### PR DESCRIPTION
Hi, this PR adds a state to ImageSegmentation component to keep Annotator's selectedTool property.

Please refer https://github.com/UniversalDataTool/universal-data-tool/pull/106#issuecomment-619612134 for the purpose.
