### PR TITLE
Show and hide labelhelp pricing with enviroment variable

### DIFF
--- a/src/components/LabelView/index.js
+++ b/src/components/LabelView/index.js
@@ -36,9 +36,16 @@ export default ({
   sampleTimeToComplete,
 }) => {
   const [currentTab, setTab] = useState("label")
+  const [showLabelHelpPricing, setShowLabelHelpPricing] = useState(false)
   const posthog = usePosthog()
-  const { labelHelpEnabled } = useLabelHelp()
+  const { labelHelpEnabled, totalCost } = useLabelHelp()
   const labelOnlyMode = useIsLabelOnlyMode()
+
+  useEffect(() => {
+    if (process.env.REACT_APP_SHOW_LABELHELP_PRICING === "true")
+      setShowLabelHelpPricing(true)
+  }, [])
+
   let percentComplete = 0
   if (dataset.samples && dataset.samples.length > 0) {
     percentComplete =
@@ -150,7 +157,11 @@ export default ({
             {labelHelpEnabled && (
               <Tab
                 icon={<SupervisedUserCircleIcon />}
-                label="Label Help"
+                label={
+                  showLabelHelpPricing && totalCost
+                    ? `${totalCost}$`
+                    : "Label Help"
+                }
                 value="labelhelp"
               />
             )}


### PR DESCRIPTION
You can show Label Help price with:
`REACT_APP_SHOW_LABELHELP_PRICING=true`

![Screen Capture_select-area_20200720012945](https://user-images.githubusercontent.com/22892227/87887574-26b6a880-ca2f-11ea-9c7a-1da83b4a85cf.png)
