### PR TITLE
Duplicate build directory to help with transition routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.11.5",
   "license": "MIT",
   "main": "desktop/main.js",
-  "homepage": "https://universaldatatool.com",
+  "homepage": "https://universaldatatool.com/app/",
   "scripts": {
     "start": "cross-env PORT=6001 react-scripts start",
     "build": "npm run build:web",
@@ -12,7 +12,7 @@
     "build:babel": "cross-env NODE_ENV=production babel ./src --out-dir=./lib --copy-files && cp ./package.json ./lib/package.json && node ./lib/lib/fix-deps.js",
     "build:vanilla": "parcel build -d ./lib -o vanilla.js ./src/vanilla/index.js",
     "build:vanilla:dev": "parcel ./src/vanilla/index.js",
-    "build:web": "react-scripts build",
+    "build:web": "rimraf build && react-scripts build && cp -r build ./build-copy && mv build-copy build/app",
     "build:desktop": "cross-env REACT_APP_DESKTOP=true PUBLIC_URL=./ react-scripts build && electron-builder build && cp ./desktop/entitlements.mac.plist ./build/entitlements.mac.plist",
     "start:desktop": "cross-env BROWSER=none USE_DEV_SERVER=yes concurrently 'npm run start' 'electron ./desktop'",
     "start:desktop:build": "electron ./desktop",
@@ -74,6 +74,7 @@
     "react-dom": "^16.8.6",
     "react-markdown": "^4.1.0",
     "react-nlp-annotate": "^0.1.22",
+    "rimraf": "^3.0.2",
     "spelling": "^2.0.1"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17150,7 +17150,7 @@ rimraf@2.6.3, rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
We're moving the application location from `/` to `/app`, this change should help minimize breakage across people's applications in case people were relying on the `/` endpoint in some way.

This will allow us to create a real landing page.