### PR TITLE
fix desktop asset path routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:vanilla": "parcel build -d ./lib -o vanilla.js ./src/vanilla/index.js",
     "build:vanilla:dev": "parcel ./src/vanilla/index.js",
     "build:web": "rimraf build && react-scripts build && cp -r build ./build-copy && mv build-copy build/app",
-    "build:desktop": "cross-env REACT_APP_DESKTOP=true PUBLIC_URL=./ react-scripts build && electron-builder build && cp ./desktop/entitlements.mac.plist ./build/entitlements.mac.plist",
+    "build:desktop": "cross-env REACT_APP_DESKTOP=true PUBLIC_URL=. react-scripts build && electron-builder build && cp ./desktop/entitlements.mac.plist ./build/entitlements.mac.plist",
     "start:desktop": "cross-env BROWSER=none USE_DEV_SERVER=yes concurrently 'npm run start' 'electron ./desktop'",
     "start:desktop:build": "electron ./desktop",
     "postinstall:desktop": "electron-builder install-app-deps",


### PR DESCRIPTION
This should fix the asset error on the desktop application on windows.