### PR TITLE
disable prev/next button if there are no sample

### DIFF
--- a/src/components/WorkspaceContainer/index.js
+++ b/src/components/WorkspaceContainer/index.js
@@ -23,10 +23,15 @@ export default ({
   const headerItems = useMemo(
     () =>
       [
-        (currentSampleIndex > 0 || onPrev) && { name: "Prev", onClick: onPrev },
+        (currentSampleIndex > 0 || onPrev) && {
+          name: "Prev",
+          onClick: onPrev,
+          disabled: currentSampleIndex === 0,
+        },
         (numberOfSamples > currentSampleIndex + 1 || onNext) && {
           name: "Next",
           onClick: onNext,
+          disabled: currentSampleIndex >= numberOfSamples - 1,
         },
         { name: "Save" },
       ].filter(Boolean),


### PR DESCRIPTION
Fixing #246 
Disable the prev/next button if there is no sample data for navigating. To fix this issue, I add disable property to the header items with the condition to check the first sample and last sample. I'm excited to contribute to the project, please review it.

The result after changing:
![next](https://user-images.githubusercontent.com/8192210/92978422-ae33fd00-f45d-11ea-8db6-b40a3ec3e1b8.png)
![prev](https://user-images.githubusercontent.com/8192210/92978423-ae33fd00-f45d-11ea-8ee1-8dc8acb544cb.png)
