### PR TITLE
:fire: Fix clearing hotkeys in manage shortcuts

### DIFF
--- a/src/components/AppConfig/index.js
+++ b/src/components/AppConfig/index.js
@@ -45,6 +45,7 @@ export const AppConfigContext = createContext({
   setAppConfig: (newConfig) => undefined,
   fromConfig: (key) => undefined,
   setInConfig: (key, value) => undefined,
+  clearInConfig: (keys) => undefined,
 })
 
 export const useAppConfig = () => useContext(AppConfigContext)
@@ -82,6 +83,13 @@ export const AppConfigProvider = ({ children }) => {
           throw new Error(`Unknown config key name "${key}"`)
         }
         setAppConfig({ ...appConfig, [key]: value })
+      },
+      clearInConfig: (keys) => {
+        let config = { ...appConfig }
+        for (const key of keys) {
+          config = { ...config, [`${key}`]: null }
+        }
+        setAppConfig(config)
       },
     }
   }, [appConfig, setAppConfig])

--- a/src/components/HotkeyStorage/index.js
+++ b/src/components/HotkeyStorage/index.js
@@ -10,7 +10,7 @@ export const HotkeyContext = createContext({
 export const useHotkeyStorage = () => useContext(HotkeyContext)
 
 export const HotkeyStorageProvider = ({ children }) => {
-  const { fromConfig, setInConfig } = useAppConfig()
+  const { fromConfig, setInConfig, clearInConfig } = useAppConfig()
 
   const hotkeys = useMemo(
     () =>
@@ -38,14 +38,12 @@ export const HotkeyStorageProvider = ({ children }) => {
       hotkeys,
       keyMap,
       clearHotkeys: () => {
-        for (const { id } of hotkeys) {
-          setInConfig(`hotkeys.${id}`, null)
-        }
+        clearInConfig(hotkeys.map((key) => `hotkeys.${key.id}`))
       },
       changeHotkey: (id, newBinding) =>
         setInConfig(`hotkeys.${id}`, newBinding),
     }),
-    [setInConfig, hotkeys, keyMap]
+    [hotkeys, keyMap, clearInConfig, setInConfig]
   )
 
   return (


### PR DESCRIPTION
- Fix clearing hotkeys in Change/View Hotkeys Setting.
- Bug Scenario: In the old version, the clear hotkeys will be set each hotkey to a NULL value and save it into local storage with use useLocalStorage of react-use. However, everytime reset each hotkey, the appConfig will not change(it only changes when reset one hotkey) because appConfig will be cache in useMemo, so everytime the key change, it will be use the initial config of app config.
- The solution: Reset all the keys at the same time instead of resetting each key.