### PR TITLE
Cypress command for aws utilities (Feature Aws Part)

### DIFF
--- a/cypress/integration/utils/cypress-command/add-asset-to-aws-project.js
+++ b/cypress/integration/utils/cypress-command/add-asset-to-aws-project.js
@@ -1,0 +1,42 @@
+import datasetManagerCognito from "udt-dataset-managers/dist/CognitoDatasetManager"
+import mime from "mime-types"
+const command = () => {
+  Cypress.Commands.add("addAssetToAwsProject", (nameProject, nameAsset) => {
+    var credentials = Cypress.env()
+    cy.log("Add test files : " + nameAsset)
+    cy.fixture("assets-dummies/" + nameAsset, "base64").then(
+      { timeout: 100000 },
+      async (asset) => {
+        var blob
+        if (nameAsset.match(".*\\.json")) {
+          blob = asset
+        } else {
+          blob = await Cypress.Blob.base64StringToBlob(
+            asset,
+            mime.lookup(nameAsset)
+          )
+        }
+        const authConfig = {
+          Auth: {
+            identityPoolId: credentials.AWS_IDENTITY_POOL_ID,
+            region: credentials.AWS_AUTH_REGION,
+            userPoolId: credentials.AWS_USER_POOL_ID,
+            userPoolWebClientId: credentials.AWS_USER_POOL_WEB_CLIENT_ID,
+            mandatorySignIn: credentials.AWS_MANDATORY_SIGN_IN,
+            authenticationFlowType: credentials.AWS_AUTHENTICATION_FLOW_TYPE,
+          },
+          Storage: {
+            AWSS3: {
+              bucket: credentials.AWS_STORAGE_BUCKET,
+              region: credentials.AWS_STORAGE_REGION,
+            },
+          },
+        }
+        const ds = await new datasetManagerCognito({ authConfig })
+        ds.setProject(nameProject)
+        await ds.addAsset(nameAsset, blob)
+      }
+    )
+  })
+}
+export default command

--- a/cypress/integration/utils/cypress-command/add-project-to-aws.js
+++ b/cypress/integration/utils/cypress-command/add-project-to-aws.js
@@ -1,0 +1,31 @@
+import datasetManagerCognito from "udt-dataset-managers/dist/CognitoDatasetManager"
+const command = () => {
+  Cypress.Commands.add("addProjectToAws", (nameDummies) => {
+    var credentials = Cypress.env()
+    cy.log("Add test files : " + nameDummies)
+    cy.fixture("samples-dummies/" + nameDummies).then(
+      { timeout: 100000 },
+      async (dummies) => {
+        const authConfig = {
+          Auth: {
+            identityPoolId: credentials.AWS_IDENTITY_POOL_ID,
+            region: credentials.AWS_AUTH_REGION,
+            userPoolId: credentials.AWS_USER_POOL_ID,
+            userPoolWebClientId: credentials.AWS_USER_POOL_WEB_CLIENT_ID,
+            mandatorySignIn: credentials.AWS_MANDATORY_SIGN_IN,
+            authenticationFlowType: credentials.AWS_AUTHENTICATION_FLOW_TYPE,
+          },
+          Storage: {
+            AWSS3: {
+              bucket: credentials.AWS_STORAGE_BUCKET,
+              region: credentials.AWS_STORAGE_REGION,
+            },
+          },
+        }
+        const ds = await new datasetManagerCognito({ authConfig })
+        await ds.setDataset(dummies)
+      }
+    )
+  })
+}
+export default command

--- a/cypress/integration/utils/cypress-command/clean-aws.js
+++ b/cypress/integration/utils/cypress-command/clean-aws.js
@@ -1,0 +1,33 @@
+import commandRemoveAwsProject from "./remove-aws-project"
+const command = () => {
+  commandRemoveAwsProject()
+  Cypress.Commands.add("cleanAws", () => {
+    cy.log("Start cleaning aws")
+    cy.removeAwsProject("Not Supported")
+    cy.removeAwsProject("Image Classification")
+    cy.removeAwsProject("Image Segmentation")
+    cy.removeAwsProject("Time Series")
+    cy.removeAwsProject("Time Series 2")
+    cy.removeAwsProject("Data Entry")
+    cy.removeAwsProject("Text Classification")
+    cy.removeAwsProject("Video Segmentation")
+    cy.removeAwsProject("Audio Transcription")
+    cy.removeAwsProject("Empty")
+    cy.removeAwsProject("Rename Test")
+    cy.removeAwsProject("CypressTestExportAnnotationOnlyTime")
+    cy.removeAwsProject("CypressTestExportAnnotationOnlyImage")
+    cy.removeAwsProject("CypressTestExportAnnotationOnlyVideo")
+    cy.removeAwsProject("CypressTestExportAnnotationOnlyPDF")
+    cy.removeAwsProject("CypressTestExportAnnotationOnlyAudio")
+    cy.removeAwsProject("CypressTestExportAnnotationOnlyText")
+    cy.removeAwsProject("CypressTestExportAssetsTime")
+    cy.removeAwsProject("CypressTestExportAssetsTime2")
+    cy.removeAwsProject("CypressTestExportAssetsImage")
+    cy.removeAwsProject("CypressTestExportAssetsVideo")
+    cy.removeAwsProject("CypressTestExportAssetsPDF")
+    cy.removeAwsProject("CypressTestExportAssetsAudio")
+    cy.removeAwsProject("CypressTestExportAssetsText")
+    cy.log("End cleaning aws")
+  })
+}
+export default command

--- a/cypress/integration/utils/cypress-command/credentials-aws.js
+++ b/cypress/integration/utils/cypress-command/credentials-aws.js
@@ -1,0 +1,78 @@
+import Amplify, { Auth } from "aws-amplify"
+
+const command = () => {
+  Cypress.Commands.add("createCredentialsAws", () => {
+    cy.then({ timeout: 10000 }, async () => {
+      const app_config = {
+        "auth.cognito.identityPoolId": Cypress.env().AWS_IDENTITY_POOL_ID,
+        "auth.cognito.region": Cypress.env().AWS_AUTH_REGION,
+        "auth.cognito.userPoolId": Cypress.env().AWS_USER_POOL_ID,
+        "auth.cognito.userPoolWebClientId": Cypress.env()
+          .AWS_USER_POOL_WEB_CLIENT_ID,
+        "auth.cognito.storage.awsS3.bucket": Cypress.env().AWS_STORAGE_BUCKET,
+        "auth.cognito.storage.awsS3.region": Cypress.env().AWS_STORAGE_REGION,
+        "auth.cognito.password.minimumLength": Cypress.env()
+          .COGNITO_USER_PASS_LENGTH,
+        "auth.cognito.password.requireLowercase":
+          Cypress.env().COGNITO_USER_PASS_REQUIRE_LOWERCASE === "TRUE"
+            ? true
+            : false,
+        "auth.cognito.password.requireUppercase":
+          Cypress.env().COGNITO_USER_PASS_REQUIRE_UPPERCASE === "TRUE"
+            ? true
+            : false,
+        "auth.cognito.password.requireNumbers":
+          Cypress.env().COGNITO_USER_PASS_REQUIRE_NUMBER === "TRUE"
+            ? true
+            : false,
+        "auth.cognito.password.requireSymbols":
+          Cypress.env().COGNITO_USER_PASS_REQUIRE_SYMBOL === "TRUE"
+            ? true
+            : false,
+        "auth.provider": "cognito",
+        provider: "cognito",
+      }
+      const json = {
+        Auth: {
+          identityPoolId: Cypress.env().AWS_IDENTITY_POOL_ID,
+          region: Cypress.env().AWS_AUTH_REGION,
+          userPoolId: Cypress.env().AWS_USER_POOL_ID,
+          userPoolWebClientId: Cypress.env().AWS_USER_POOL_WEB_CLIENT_ID,
+          mandatorySignIn: true,
+          authenticationFlowType: "USER_PASSWORD_AUTH",
+          minimumLength: Cypress.env().COGNITO_USER_PASS_LENGTH,
+          requireNumbers:
+            Cypress.env().COGNITO_USER_PASS_REQUIRE_NUMBER === "TRUE"
+              ? true
+              : false,
+          requireSymbols:
+            Cypress.env().COGNITO_USER_PASS_REQUIRE_SYMBOL === "TRUE"
+              ? true
+              : false,
+          requireUppercase:
+            Cypress.env().COGNITO_USER_PASS_REQUIRE_UPPERCASE === "TRUE"
+              ? true
+              : false,
+          requireLowercase:
+            Cypress.env().COGNITO_USER_PASS_REQUIRE_LOWERCASE === "TRUE"
+              ? true
+              : false,
+        },
+        Storage: {
+          AWSS3: {
+            bucket: Cypress.env().AWS_STORAGE_BUCKET,
+            region: Cypress.env().AWS_STORAGE_REGION,
+          },
+        },
+      }
+      localStorage.setItem("app_config", JSON.stringify(app_config))
+      Amplify.configure(json)
+      await Auth.signIn(
+        Cypress.env().COGNITO_USER_NAME,
+        Cypress.env().COGNITO_USER_PASS
+      )
+    })
+    cy.reload()
+  })
+}
+export default command

--- a/cypress/integration/utils/cypress-command/remove-aws-project.js
+++ b/cypress/integration/utils/cypress-command/remove-aws-project.js
@@ -1,0 +1,26 @@
+import datasetManagerCognito from "udt-dataset-managers/dist/CognitoDatasetManager"
+
+const command = () => {
+  Cypress.Commands.add("removeAwsProject", async (name) => {
+    var credentials = Cypress.env()
+    const authConfig = {
+      Auth: {
+        identityPoolId: credentials.AWS_IDENTITY_POOL_ID,
+        region: credentials.AWS_AUTH_REGION,
+        userPoolId: credentials.AWS_USER_POOL_ID,
+        userPoolWebClientId: credentials.AWS_USER_POOL_WEB_CLIENT_ID,
+        mandatorySignIn: credentials.AWS_MANDATORY_SIGN_IN,
+        authenticationFlowType: credentials.AWS_AUTHENTICATION_FLOW_TYPE,
+      },
+      Storage: {
+        AWSS3: {
+          bucket: credentials.AWS_STORAGE_BUCKET,
+          region: credentials.AWS_STORAGE_REGION,
+        },
+      },
+    }
+    const ds = await new datasetManagerCognito({ authConfig })
+    await ds.removeProject(name)
+  })
+}
+export default command

--- a/cypress/integration/utils/cypress-command/set-up-aws.js
+++ b/cypress/integration/utils/cypress-command/set-up-aws.js
@@ -1,0 +1,29 @@
+import commandAddAssetToAwsProject from "./add-asset-to-aws-project"
+import commandAddProjectToAws from "./add-project-to-aws"
+const command = () => {
+  commandAddAssetToAwsProject()
+  commandAddProjectToAws()
+  Cypress.Commands.add("setUpAws", () => {
+    cy.addProjectToAws("ImageClassification.json")
+    cy.addProjectToAws("Empty.json")
+    cy.addProjectToAws("AudioTranscription.json")
+    cy.addProjectToAws("VideoSegmentation.json")
+    cy.addProjectToAws("TextClassification.json")
+    cy.addProjectToAws("TimeSeriesTimeData.json")
+    cy.addProjectToAws("TimeSeriesAudioUrl.json")
+    cy.addProjectToAws("DataEntry.json")
+    cy.addProjectToAws("NotSupported.json")
+    cy.addAssetToAwsProject("Image Classification", "image1.jpg")
+    cy.addAssetToAwsProject("Image Classification", "image2.jpg")
+    cy.addAssetToAwsProject("Audio Transcription", "audio.mp3")
+    cy.addAssetToAwsProject("Video Segmentation", "video.mp4")
+    cy.addAssetToAwsProject("Data Entry", "pdf1.pdf")
+    cy.addAssetToAwsProject("Data Entry", "pdf2.pdf")
+    cy.addAssetToAwsProject("Text Classification", "text1.txt")
+    cy.addAssetToAwsProject("Text Classification", "text2.txt")
+    cy.addAssetToAwsProject("Text Classification", "text3.txt")
+    cy.addAssetToAwsProject("Time Series", "audio.mp3")
+    cy.addAssetToAwsProject("Time Series 2", "timeSeries.json")
+  })
+}
+export default command


### PR DESCRIPTION
Allow to use aws in cypress command.
Boon :
Easy use in test file 
Optimal way to do the async job in cypress framework

add-asset-to-aws-project.js
Add an asset to existing/non-existing project

add-project-to-aws.js
Add a project to aws

clean-aws.js
Clean all fixture for aws test

credentials-aws.js
Allow to connect with aws without passing by the credentials feature

remove-aws-project.js
Remove a project and its subfolder

set-up-aws.js
Add the fixture for aws test to aws