### PR TITLE
Fix the problem images disappear with a large number of labels in Image Classification, together with small UI improvements.

### DIFF
--- a/src/components/ImageClassification/index.js
+++ b/src/components/ImageClassification/index.js
@@ -41,6 +41,7 @@ const ImageContainer = styled("div")({
   position: "relative",
   display: "flex",
   flexGrow: 1,
+  minHeight: '20vh',
 })
 
 const Image = styled("img")({

--- a/src/components/RawJSONEditor/index.js
+++ b/src/components/RawJSONEditor/index.js
@@ -21,6 +21,7 @@ export const RawJSONEditor = ({ content, onSave }) => {
         theme="github"
         mode="javascript"
         width="100%"
+        height="calc(100vh - 80px)"
         value={jsonText}
         editorProps={{ $blockScrolling: Infinity }}
         onChange={(t) => setJSONText(t)}

--- a/src/components/WorkspaceContainer/index.js
+++ b/src/components/WorkspaceContainer/index.js
@@ -64,7 +64,7 @@ export default ({
       iconSidebarItems={[]}
       rightSidebarItems={[]}
     >
-      <Box padding={2} style={{ width: "100%" }}>
+      <Box padding={2, 0} style={{ width: "100%" }}>
         {children}
       </Box>
     </Workspace>


### PR DESCRIPTION
Related with #533 

Fix the problem images disappear with a large number of labels
- By adding min-height to the `ImageContainer`

![chrome_OUnsocKWma](https://user-images.githubusercontent.com/25426917/153711987-53d28dbd-2713-4680-a17b-cab28f60aa19.png)

---

And also with Small UI improvements:
- Fix "strange" bottom scroll bar
- Make JSON Editor full of the window's height instead of default's 500px

When Image Classification, there is a bottom scroll bar which seems strange and unnecessary:

![firefox_ox34mfNpSO](https://user-images.githubusercontent.com/25426917/153711795-98607b8f-2557-4a47-8438-0144d9a7c056.png)

And also make the JSON Editor full of the window's height for more visibility:
 
![chrome_9hKOE9GAsh](https://user-images.githubusercontent.com/25426917/153711899-7c16fd0f-568c-4915-9ebb-685685069d8c.png)

